### PR TITLE
Fix vehicle stopping lane search for on-demand vehicles

### DIFF
--- a/activitygen.py
+++ b/activitygen.py
@@ -1233,7 +1233,8 @@ class MobilityGenerator():
     def _get_stopping_lane(self, edge, vtype):
         """ Returns the vehicle-friendly stopping lange closer to the sidewalk. """
         for lane in self._sumo_network.getEdge(edge).getLanes():
-            if lane.allows(vtype):
+            sumoVehicleType = 'taxi' if vtype == 'on-demand' else vtype
+            if lane.allows(sumoVehicleType):
                 return lane.getID()
         raise TripGenerationGenericError('"{}" cannot stop on edge {}'.format(vtype, edge))
 


### PR DESCRIPTION
For trips with `vtype = 'on-demand'` function `_get_stopping_lane` fails cause there is no such type.

I suppose it should be a `taxi` so I just patched argument for `lane.allows` call and didn't touch another `activitygen` logic.