### PR TITLE
making folium optional

### DIFF
--- a/generateTAZBuildingsFromOSM.py
+++ b/generateTAZBuildingsFromOSM.py
@@ -20,7 +20,6 @@ import xml.etree.ElementTree
 from functools import partial
 import pyproj
 import numpy
-import folium
 
 import shapely.geometry as geometry
 from shapely.ops import transform
@@ -123,6 +122,7 @@ class GenerateTAZandWeightsFromOSM():
 
     def save_taz_to_osm(self, filename):
         """ Plot the boundaries using folium to html file."""
+        import folium
         print("Plotting TAZ to OpenStreetMap in file {}.".format(filename))
         colors = ['#0000FF', '#0040FF', '#0080FF', '#00FFB0', '#00E000', '#80FF00',
                   '#FFFF00', '#FFC000', '#FF0000']


### PR DESCRIPTION
there seems to be no folium package in ubuntu so people who do not want to mix pip and apt installed python packages have a problem