### PR TITLE
Fix intermodal home/primary edge selection for PT

### DIFF
--- a/agsrc/activities.py
+++ b/agsrc/activities.py
@@ -107,7 +107,7 @@ class Activities():
             if self._env.valid_pair(from_edge, to_edge) and from_allowed and to_allowed:
                 try:
                     route = self._sumo.simulation.findIntermodalRoute(
-                        from_edge, to_edge, modes=_mode, pType=_ptype, vType=_vtype)
+                        from_edge, to_edge, modes=_mode, pType=_ptype, vType=_vtype, lenient=True)
                     if not sumoutils.is_valid_route(
                             mode, route, self._conf['intermodalOptions']['vehicleAllowedParking']):
                         route = None

--- a/agsrc/sumoutils.py
+++ b/agsrc/sumoutils.py
@@ -49,7 +49,7 @@ def get_intermodal_mode_parameters(mode, parking_requirements):
         return '', '', mode     # Required to avoid the exchange point outside the parkingStop
     return 'car', '', mode      # Enables the walk from the exchange points to destination
 
-def is_valid_route(mode, route, parking_requirements):
+def is_valid_route(mode, route, parking_requirements, lenient=False):
     """ Handle findRoute and findIntermodalRoute results. """
     if route is None:
         # traci failed
@@ -61,6 +61,8 @@ def is_valid_route(mode, route, parking_requirements):
         if len(route.edges) >= 2:
             return True
     elif _mode == 'public':
+        if lenient:
+            return True
         for stage in route:
             if stage.line:
                 return True


### PR DESCRIPTION
When selecting home/primary edges, traci.simulation.findIntermodalRoute() is used to see if the edges are reachable. When mode is public and no depart time is input, the function returns a walking route. This is then considered invalid by sumoutils.is_valid_route(), so PT route generation always fails.

See https://github.com/lcodeca/SUMOActivityGen/issues/45

Here, I just added a flag to the is_valid_route() function to give leniency (i.e., route is valid if it is reachable by ANY mode) only when mode is public. Note that this leniency is only given during this edge selection part.